### PR TITLE
Add EFI RT Properties Table tests

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestRequired_uefi.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestRequired_uefi.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024 HP Development Company, L.P. <BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestRequired_uefi.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestRequired_uefi.c
@@ -772,7 +772,7 @@ CheckRuntimePropertiesTable (
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType,
-                 gEfiCompliantBbTestRequiredAssertionGuid004,
+                 gEfiCompliantBbTestRequiredAssertionGuid010,
                  L"UEFI Compliant - EFI Runtime Properties Table must be implemented",
                  L"%a:%d:Status - %r, Expected - %r",
                  __FILE__,
@@ -813,7 +813,7 @@ CheckRuntimePropertiesTable (
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType,
-                 gEfiCompliantBbTestRequiredAssertionGuid003,
+                 gEfiCompliantBbTestRequiredAssertionGuid010,
                  L"UEFI Compliant - EFI Runtime Properties Table RuntimeServicesSupported variable must be implemented",
                  L"%a:%d:RuntimeServicesSupported - 0x%x, Expected - 0x%x",
                  __FILE__,

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTest_uefi.inf
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTest_uefi.inf
@@ -2,6 +2,7 @@
 #
 #  Copyright 2006 - 2016 Unified EFI, Inc.<BR>
 #  Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2024 HP Development Company, L.P. <BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTest_uefi.inf
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTest_uefi.inf
@@ -51,6 +51,10 @@
   UefiDriverEntryPoint
   SctLib
   EfiTestLib
+  UefiLib
+
+[Guids]
+  gEfiRtPropertiesTableGuid
 
 [Protocols]
   gEfiDebugPortProtocolGuid

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/Guid_uefi.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/Guid_uefi.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024 HP Development Company, L.P. <BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -99,3 +100,5 @@ EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid006 = EFI_TEST_EFICOMPLIANTBBTE
 EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid008 = EFI_TEST_EFICOMPLIANTBBTESTREQUIRED_ASSERTION_008_GUID;
 
 EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid009 = EFI_TEST_EFICOMPLIANTBBTESTREQUIRED_ASSERTION_009_GUID;
+
+EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid010 = EFI_TEST_EFICOMPLIANTBBTESTREQUIRED_ASSERTION_010_GUID;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/Guid_uefi.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/Guid_uefi.h
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024 HP Development Company, L.P. <BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -204,4 +205,9 @@ extern EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid008;
 { 0xf6334f9b, 0xb930, 0x4adb, {0xa5, 0x3b, 0x76, 0xfa, 0x7b, 0x4c, 0x27, 0x62 }}
 
 extern EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid009;
+
+#define EFI_TEST_EFICOMPLIANTBBTESTREQUIRED_ASSERTION_010_GUID \
+{ 0xe6c7861f, 0x350e, 0x4a4c, {0xbe, 0x57, 0xcb, 0xde, 0xfd, 0xbb, 0x56, 0x89 }}
+
+extern EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid010;
 


### PR DESCRIPTION
Adds tests to verify the EFI RT Properties Table installation and RuntimeServicesSupported variable validity.

The EFI_RT_PROPERTIES_TABLE is defined in section 4.6 EFI Configuration Table & Properties Table in the UEFI Spec 2.8 Errata C document.